### PR TITLE
Address discovery using Service DNS records

### DIFF
--- a/TTalk.WinUI/App.xaml.cs
+++ b/TTalk.WinUI/App.xaml.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿using DnsClient;
+
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.UI.Xaml;
@@ -93,7 +95,7 @@ namespace TTalk.WinUI
                 // Configuration
                 services.Configure<LocalSettingsOptions>(context.Configuration.GetSection(nameof(LocalSettingsOptions)));
 
-
+                services.AddSingleton<ILookupClient>(new LookupClient());
             })
             .Build();
 
@@ -117,7 +119,7 @@ namespace TTalk.WinUI
         
         public static void ResetMainViewModel()
         {
-            _mainViewModel = new(GetService<ILocalSettingsService>(), GetService<ILogger<MainViewModel>>(), GetService<SoundService>(), GetService<KeyBindingsService>());
+            _mainViewModel = new(GetService<ILocalSettingsService>(), GetService<ILogger<MainViewModel>>(), GetService<SoundService>(), GetService<KeyBindingsService>(), GetService<ILookupClient>());
         }
 
         private void App_UnhandledException(object sender, Microsoft.UI.Xaml.UnhandledExceptionEventArgs e)

--- a/TTalk.WinUI/TTalk.WinUI.csproj
+++ b/TTalk.WinUI/TTalk.WinUI.csproj
@@ -60,6 +60,7 @@
 		<PackageReference Include="CommunityToolkit.WinUI.UI.Controls.Primitives" Version="7.1.2" />
 		<PackageReference Include="CommunityToolkit.WinUI.UI.Media" Version="7.1.2" />
 		<PackageReference Include="DebounceThrottle" Version="1.0.0" />
+		<PackageReference Include="DnsClient" Version="1.6.0" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />


### PR DESCRIPTION
The client will now look for the `_ttalk._tcp.{domain}` SRV record if an address is not in a `address:port` format.